### PR TITLE
Fix link GOAP

### DIFF
--- a/book_GameAI/10_metodi.md
+++ b/book_GameAI/10_metodi.md
@@ -174,7 +174,7 @@ gli steps sono:
 ![](img/ai_treesearch_montecarlo.webp)
 
 ### GOAP
-vedere [[12_GOAP)
+vedere [GOAP](12_GOAP.md)
 
 ### Navigation Flocking
 - **Separation**: Each boid needs to maintain a minimum distance with neighboring boids to avoid hitting them (short-range repulsion) 


### PR DESCRIPTION
Nella preview del sito il link era rotto, nella preview di github funziona con questo fix, non so nel sito. Fammi sapere 👍🏻